### PR TITLE
Mildly hacky support for determining if a vehicle model is ELS

### DIFF
--- a/Albo1125.Common/CommonLibrary/ExtensionMethods.cs
+++ b/Albo1125.Common/CommonLibrary/ExtensionMethods.cs
@@ -8,6 +8,7 @@ using System.Drawing;
 using System.Windows.Forms;
 using Albo1125.Common.CommonLibrary;
 using System.Globalization;
+using System.IO;
 
 namespace Albo1125.Common.CommonLibrary
 {
@@ -446,6 +447,61 @@ namespace Albo1125.Common.CommonLibrary
         {
             NativeFunction.Natives.SET_VEHICLE_COLOURS(v, (int)color.PrimaryColor, (int)color.SecondaryColor);
         }
+
+        /// <summary>
+        /// Cache the result of whether a vehicle is an ELS vehicle.
+        /// </summary>
+        private static Dictionary<Model, bool> vehicleModelELSCache = new Dictionary<Model, bool>();
+
+        /// <summary>
+        /// Determine whether the passed vehicle model is an ELS vehicle.
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns></returns>
+        public static bool VehicleModelIsELS(Model model)
+        {
+            try
+            {
+                if (vehicleModelELSCache.ContainsKey(model))
+                {
+                    return vehicleModelELSCache[model];
+                }
+
+                if (!Directory.Exists(Path.Combine(Directory.GetCurrentDirectory(), "ELS")))
+                {
+                    // no ELS installation at all
+                    vehicleModelELSCache.Add(model, false);
+                    return false;
+                }
+
+                IEnumerable<string> elsFiles = Directory.EnumerateFiles(
+                    Path.Combine(Directory.GetCurrentDirectory(), "ELS"),
+                    $"{model.Name}.xml", SearchOption.AllDirectories);
+
+                vehicleModelELSCache.Add(model, elsFiles.Any());
+                return vehicleModelELSCache[model];
+            }
+            catch (Exception e)
+            {
+                Game.LogTrivial($"Failed to determine if a vehicle model '{model}' was ELS-enabled: {e}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Determine whether the passed vehicle is an ELS vehicle.
+        /// </summary>
+        /// <param name="vehicle"></param>
+        /// <returns></returns>
+        public static bool VehicleModelIsELS(Vehicle vehicle)
+        {
+            if (vehicle)
+            {
+                return VehicleModelIsELS(vehicle.Model);
+            }
+            return false;
+        }
+
     }
 
 


### PR DESCRIPTION
Support in the Common library for determining if a vehicle model is an ELS model. Because of the lack of an API for disabling the siren for ELS cars, it is sometimes beneficial to be able to treat ELS police cars differently in terms of enabling/disabling the lights.